### PR TITLE
Update CommandUtils.hx

### DIFF
--- a/src/utils/CommandUtils.hx
+++ b/src/utils/CommandUtils.hx
@@ -318,7 +318,7 @@ class CommandUtils
 			while (true)
 			{
 				var line:String = proc.stdout.readLine();
-				if (line == "-D " + Name)
+				if (StringTools.startsWith(line,"-D " + Name + "="))
 				{
 					result = previous;
 					break;


### PR DESCRIPTION
`getHaxelibPath` was always returning `null`, it would never find a line that `== "-D haxelibname"`.