### PR TITLE
Fix typo in error message for setup command

### DIFF
--- a/src/commands/SetupCommand.hx
+++ b/src/commands/SetupCommand.hx
@@ -18,7 +18,7 @@ class SetupCommand extends Command
 		setupFlixel();
 
 		if (console.args.length > 3)
-			error("You have given too many arguments for the create command.");
+			error("You have given too many arguments for the setup command.");
 
 		if (console.getOption("-y") != null)
 			autoContinue = true;


### PR DESCRIPTION
It appears the argument-count-related error message for the setup command was copied from the create command without modification. This patch changes the word "create" to "setup" in the error message for the setup command.