### PR TITLE
Modified flixel ln -s path to avoid permissions error

### DIFF
--- a/src/commands/SetupCommand.hx
+++ b/src/commands/SetupCommand.hx
@@ -122,7 +122,7 @@ class SetupCommand extends Command
 				{
 					Sys.command("sudo", ["cp", flixelAliasScript, haxePath + "/flixel"]);
 					Sys.command("sudo", ["chmod", "755", haxePath + "/flixel"]);
-					Sys.command("sudo", ["ln", "-s", haxePath + "/flixel", "/usr/bin/flixel"]);
+					Sys.command("sudo", ["ln", "-s", haxePath + "/flixel", "/usr/local/bin/flixel"]);
 				}
 				else
 				{


### PR DESCRIPTION
This should remove the problem of installing on Mac, as the user executing the setup script does not have permission to the /usr/bin directory.