### PR TITLE
Create directory for 'flixel' script if it doesn't exist (possibly fixes #62)

### DIFF
--- a/src/commands/SetupCommand.hx
+++ b/src/commands/SetupCommand.hx
@@ -119,6 +119,9 @@ class SetupCommand extends Command
 				if (haxePath == null || haxePath == "")
 					haxePath = libPath + "/haxe";
 
+				if (!FileSystem.exists(haxePath))
+					FileSystem.createDirectory(haxePath);
+
 				flixelAliasScript = CommandUtils.getHaxelibPath("flixel-tools") + "bin/flixel.sh";
 
 				if (FileSystem.exists(flixelAliasScript))


### PR DESCRIPTION
I encountered the same problem as described in #62, and found out that creating directory where `flixel.sh` is copied into resolves that issue.


Also I'm not sure if I should include built `run.n` file in this commit.