### PR TITLE
Setup Error Solution, closes #62

### DIFF
--- a/src/commands/SetupCommand.hx
+++ b/src/commands/SetupCommand.hx
@@ -125,7 +125,8 @@ class SetupCommand extends Command
 
 				if (FileSystem.exists(flixelAliasScript))
 				{
-					Sys.command("sudo", ["cp", flixelAliasScript, binPath + "/flixel"]);					
+					Sys.command("sudo", ["cp", flixelAliasScript, binPath + "/flixel"]);
+					Sys.command("sudo", ["chmod", "+x", binPath + "/flixel"]);					
 				}
 				else
 				{

--- a/src/commands/SetupCommand.hx
+++ b/src/commands/SetupCommand.hx
@@ -67,7 +67,7 @@ class SetupCommand extends Command
 				runDownloadCommand();
 		}
 	}
-	
+
 	private function runDownloadCommand():Void
 	{
 		Sys.command("haxelib", ["run", "flixel-tools", "download"]);
@@ -91,7 +91,7 @@ class SetupCommand extends Command
 		if (autoContinue || answer == Answer.Yes)
 		{
 			isAliasSetUp = true;
-			
+
 			var haxePath:String = Sys.getEnv("HAXEPATH");
 			var flixelAliasScript = "";
 
@@ -125,9 +125,7 @@ class SetupCommand extends Command
 
 				if (FileSystem.exists(flixelAliasScript))
 				{
-					Sys.command("sudo", ["cp", flixelAliasScript, haxePath + "/flixel"]);
-					Sys.command("sudo", ["chmod", "755", haxePath + "/flixel"]);
-					Sys.command("sudo", ["ln", "-s", haxePath + "/flixel", binPath + "/flixel"]);
+					Sys.command("sudo", ["cp", flixelAliasScript, binPath + "/flixel"]);					
 				}
 				else
 				{
@@ -147,7 +145,7 @@ class SetupCommand extends Command
 		var ideaFlixelEngine = "Flixel Engine";
 		var ideaFlixelAddons = "Flixel Addons";
 		var ideaPath = "/Applications/Cardea-IU-130.1619.app/Contents/MacOS/idea";
-		
+
 		ide = CommandUtils.askQuestionStrings("Choose your default IDE:", ides);
 		if (ide == null)
 		{

--- a/src/commands/SetupCommand.hx
+++ b/src/commands/SetupCommand.hx
@@ -91,17 +91,14 @@ class SetupCommand extends Command
 		if (autoContinue || answer == Answer.Yes)
 		{
 			isAliasSetUp = true;
-
-			var haxePath:String = Sys.getEnv("HAXEPATH");
-			var flixelAliasScript = "";
-
+			
 			if (FileSys.isWindows)
 			{
+				var haxePath:String = Sys.getEnv("HAXEPATH");
 				if (haxePath == null || haxePath == "")
 					haxePath = "C:\\HaxeToolkit\\haxe\\";
 
-				flixelAliasScript = haxePath + "\\flixel.bat";
-
+				var flixelAliasScript = haxePath + "\\flixel.bat";
 				var scriptSourcePath = CommandUtils.getHaxelibPath("flixel-tools");
 				var scriptFile = "flixel.bat";
 				scriptSourcePath = CommandUtils.combine(scriptSourcePath, "bin");
@@ -118,15 +115,12 @@ class SetupCommand extends Command
 			}
 			else
 			{
-				if (haxePath == null || haxePath == "")
-					haxePath = libPath + "/haxe";
-
-				flixelAliasScript = CommandUtils.getHaxelibPath("flixel-tools") + "bin/flixel.sh";
+				var flixelAliasScript = CommandUtils.getHaxelibPath("flixel-tools") + "bin/flixel.sh";
 
 				if (FileSystem.exists(flixelAliasScript))
 				{
 					Sys.command("sudo", ["cp", flixelAliasScript, binPath + "/flixel"]);
-					Sys.command("sudo", ["chmod", "+x", binPath + "/flixel"]);					
+					Sys.command("sudo", ["chmod", "+x", binPath + "/flixel"]);
 				}
 				else
 				{


### PR DESCRIPTION
The problam:
setup was always traing to create a /usr/lib/haxe/flixel and then a link in /usr/bin/flixel to the script. But some users don't have a /usr/lib/haxe folder and setup would fail.

Solution:
Just create the script in the /usr/bin/flixel. I don't see why the link is needed. But i may not know enough so...
The script is just calling "haxelib run flixel-tools $args" that is why i think of no problam to put the file in the /usr/bin folder.

Another solution would be prompt the user to chose the location and the default location would be /usr/bin

To clarify, the previous solution tried to put the flixel.sh script in a folder above haxelib folder were /usr/lib/haxe is a folder created by the user as per old.haxe.org instructions and /usr/lib/haxe/lib was where old.haxe instructed user to setup haxelib.
The previous solution relies on the notion that every user will have a haxe folder with haxelib folder inside and that is not true anymore.

After the changes some things are not used anymore but i did not clean the method so even if the solution is satisfactory you may declaine the pull(if you want).