### PR TITLE
Use Neko instead of Flash for code completion

### DIFF
--- a/src/utils/TemplateUtils.hx
+++ b/src/utils/TemplateUtils.hx
@@ -109,7 +109,7 @@ class TemplateUtils
 		FileSysUtils.runInDirectory(templatePath, function()
 		{
 			Sys.println("Initializing project for code completion...");
-			runCommand("haxelib", ["run", "lime", "update", "flash", "-debug"]);
+			runCommand("haxelib", ["run", "lime", "update", "neko", "-debug"]);
 			Sys.println("");
 		});
 	}


### PR DESCRIPTION
As was discussed in the Discord, it makes more sense to build code completion for Neko instead of Flash, especially now that Flash is on its way out and Neko is the default target for vshaxe.