### PR TITLE
stop unknown ide option causing a crash

### DIFF
--- a/src/commands/TemplateCommand.hx
+++ b/src/commands/TemplateCommand.hx
@@ -30,7 +30,7 @@ class TemplateCommand extends Command
 		if (console.getOption("-y") != null)
 			autoContinue = true;
 
-		ideOption = ProjectUtils.resolveIDEChoice(console);
+		ideOption = ProjectUtils.resolveIDEChoice(console, autoContinue);
 
 		if (console.getOption("-n") != null)
 			targetPath = console.getOption("-n");

--- a/src/utils/ProjectUtils.hx
+++ b/src/utils/ProjectUtils.hx
@@ -140,7 +140,7 @@ class ProjectUtils
 		return replacements;
 	}
 
-	public static function resolveIDEChoice(console:Console, autoContinue=false):IDE
+	public static function resolveIDEChoice(console:Console, autoContinue = false):IDE
 	{
 		var options = [
 			"subl" => IDE.SUBLIME_TEXT,

--- a/src/utils/ProjectUtils.hx
+++ b/src/utils/ProjectUtils.hx
@@ -140,7 +140,7 @@ class ProjectUtils
 		return replacements;
 	}
 
-	public static function resolveIDEChoice(console:Console):IDE
+	public static function resolveIDEChoice(console:Console, autoContinue=false):IDE
 	{
 		var options = [
 			"subl" => IDE.SUBLIME_TEXT,
@@ -157,6 +157,23 @@ class ProjectUtils
 		var ideOption = console.getOption("ide");
 		if (ideOption != null)
 			ide = options[ideOption];
+
+		if (ide == null)
+		{
+			Sys.println('Warning: $ideOption is not a recognized option.');
+
+			var answer = Answer.No;
+
+			if (!autoContinue)
+			{
+				answer = CommandUtils.askYN("Abort? (Will not use any ide if continue)");
+			}
+			if (answer == Answer.Yes)
+			{
+				Sys.exit(1);
+			}
+			ide = IDE.NONE;
+		}
 
 		return ide;
 	}


### PR DESCRIPTION
` haxelib run flixel-tools tpl -ide idename -n name`  used to crash when there is a typo in idename or it's not one of the recognized options. This stops that and asks user to either abort or let script continue with `none` ide.