### PR TITLE
change haxeflixel.com url prefix from `www.` to `https://` for better terminal clicking

### DIFF
--- a/src/FlxTools.hx
+++ b/src/FlxTools.hx
@@ -45,7 +45,7 @@ class FlxTools extends CommandLineRunner
 		Sys.println("");
 
 		Sys.println("Powered by the Haxe Toolkit and OpenFL");
-		Sys.println("Visit www.haxeflixel.com for community support and resources!");
+		Sys.println("Visit https://haxeflixel.com for community support and resources!");
 		Sys.println("");
 		Sys.println("HaxeFlixel command-line tools (" + VERSION + ")");
 


### PR DESCRIPTION
Many modern terminals automatically highlight and allow links to be clicked. In my small testing (aka just testing with Wezterm and VSCode) seems like as long as it has `https://` as it's prefix, it will detect it's a link and allow the link to be clicked easily

in this PR i didnt include the run.n since it will probably create merge conflicts with the other PR i just made hehe... so if/when both of these PRs get merged it will require the run.n to be made!